### PR TITLE
Add Windows and *BSD support (fixes #2)

### DIFF
--- a/lib/Web/Browser.hs
+++ b/lib/Web/Browser.hs
@@ -1,19 +1,25 @@
+{-# LANGUAGE CPP #-}
 module Web.Browser
 ( openBrowser
 ) where
 
+#if defined(mingw32_HOST_OS)
+import Web.Browser.Windows (openBrowserWindows)
+#else
 import Data.List (isInfixOf)
 import System.Info (os)
 import Web.Browser.Linux (openBrowserLinux)
 import Web.Browser.OSX (openBrowserOSX)
-import Web.Browser.Windows (openBrowserWindows)
+#endif
 
 -- |'openBrowser' opens a URL in the user's preferred web browser. Returns
 -- whether or not the operation succeeded.
 openBrowser :: String -> IO Bool
+#if defined(mingw32_HOST_OS)
+openBrowser = openBrowserWindows
+#else
 openBrowser
-    | "linux"   `isInfixOf` os = openBrowserLinux
-    | "darwin"  `isInfixOf` os = openBrowserOSX
-    | "mingw32" `isInfixOf` os = openBrowserWindows
-    | "bsd"     `isInfixOf` os = openBrowserLinux
-    | otherwise                = error "unsupported platform"
+    | any (`isInfixOf` os) ["linux", "bsd"] = openBrowserLinux
+    | "darwin"  `isInfixOf` os              = openBrowserOSX
+    | otherwise                             = error "unsupported platform"
+#endif

--- a/lib/Web/Browser.hs
+++ b/lib/Web/Browser.hs
@@ -6,11 +6,14 @@ import Data.List (isInfixOf)
 import System.Info (os)
 import Web.Browser.Linux (openBrowserLinux)
 import Web.Browser.OSX (openBrowserOSX)
+import Web.Browser.Windows (openBrowserWindows)
 
 -- |'openBrowser' opens a URL in the user's preferred web browser. Returns
 -- whether or not the operation succeeded.
 openBrowser :: String -> IO Bool
 openBrowser
-    | "linux"  `isInfixOf` os = openBrowserLinux
-    | "darwin" `isInfixOf` os = openBrowserOSX
-    | otherwise               = error "unsupported platform"
+    | "linux"   `isInfixOf` os = openBrowserLinux
+    | "darwin"  `isInfixOf` os = openBrowserOSX
+    | "mingw32" `isInfixOf` os = openBrowserWindows
+    | "bsd"     `isInfixOf` os = openBrowserLinux
+    | otherwise                = error "unsupported platform"

--- a/lib/Web/Browser/Windows.hs
+++ b/lib/Web/Browser/Windows.hs
@@ -1,0 +1,21 @@
+﻿module Web.Browser.Windows
+( openBrowserWindows
+) where
+
+import System.Directory (findExecutable)
+import System.Exit (ExitCode(..))
+import System.Process (system)
+
+openBrowserWindows :: String -> IO Bool
+openBrowserWindows url = do
+  mbCygstart <- findExecutable "cygstart"
+  case mbCygstart of
+       Just cygstart -> openBrowserWith cygstart url
+       Nothing       -> openBrowserWith "start" url
+
+-- We can't use rawSystem on Windows, since that doesn't pick up the "start"
+-- shell built-in.
+openBrowserWith :: FilePath -> String -> IO Bool
+openBrowserWith cmd url = exitCodeToBool `fmap` system (cmd ++ " " ++ url)
+    where exitCodeToBool ExitSuccess     = True
+          exitCodeToBool (ExitFailure _) = False

--- a/open-browser.cabal
+++ b/open-browser.cabal
@@ -18,10 +18,12 @@ source-repository head
 
 library
     exposed-modules:        Network.Browser, Web.Browser
-    other-modules:          Web.Browser.Linux, Web.Browser.OSX
+    other-modules:          Web.Browser.Linux,
+                            Web.Browser.OSX,
+                            Web.Browser.Windows
     hs-source-dirs:         lib
     default-language:       Haskell2010
-    build-depends:          base >= 4 && < 5, process >= 1 && < 2
+    build-depends:          base >= 4 && < 5, directory, process >= 1 && < 2
 
 executable example
     main-is:                Main.hs

--- a/open-browser.cabal
+++ b/open-browser.cabal
@@ -19,11 +19,13 @@ source-repository head
 library
     exposed-modules:        Network.Browser, Web.Browser
     other-modules:          Web.Browser.Linux,
-                            Web.Browser.OSX,
-                            Web.Browser.Windows
+                            Web.Browser.OSX
     hs-source-dirs:         lib
     default-language:       Haskell2010
-    build-depends:          base >= 4 && < 5, directory, process >= 1 && < 2
+    build-depends:          base >= 4 && < 5, process >= 1 && < 2
+    if os(windows)
+      build-depends:        Win32
+      other-modules:        Web.Browser.Windows
 
 executable example
     main-is:                Main.hs


### PR DESCRIPTION
This should allow `open-browser` to support Windows and *BSD OSes. I've tested these changes on PowerShell, Cygwin, MSYS, and FreeBSD, and they seem to work.