### PR TITLE
Add appveyor configuration from the stack repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
+.stack-work

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+build: off
+before_test:
+- curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\open-browser"
+
+test_script:
+- stack init --force
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.18
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.10.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Adds appveyor configuration for testing the build on windows. A badge
should be added and the CI system should be enabled to the real repository.

See the build on my fork here:

https://ci.appveyor.com/project/yamadapc/open-browser